### PR TITLE
Add diagnostic templates, more docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 With a single line of code:
 
 ```go
-return smarterr.AppendSDK(ctx, diags, err, "id", "r-1234567890")
+return smarterr.Append(ctx, diags, err, "id", "r-1234567890")
 ```
 
 smarterr uses configuration—not code changes—to split an incoming error into **three output channels**:
@@ -75,9 +75,9 @@ smarterr uses configuration—not code changes—to split an incoming error into
 2. **Call smarterr in your error handling:**
 
    ```go
-   smarterr.AppendFW(ctx, diags, err, "id", id)
+   smarterr.AddError(ctx, diags, err, "id", id)
    // or for SDK diagnostics:
-   diags = smarterr.AppendSDK(ctx, diags, err, "id", id)
+   diags = smarterr.Append(ctx, diags, err, "id", id)
    ```
 
 ### CLI Usage (Work in Progress)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ smarterr uses configuration—not code changes—to split an incoming error into
 
 **smarterr** lets you define, update, and standardize error output for thousands of call sites—using config, not code. Evolve your error messages and formatting without cross-codebase refactors. Both developers and users get cleaner, more actionable diagnostics.
 
+## Template Types and Usage
+
+smarterr supports two main template types for customizing diagnostic output:
+
+- **Error templates**: `error_summary` and `error_detail`
+  - Used when formatting diagnostics from Go errors (e.g., via `AddError` or `Append`).
+- **Diagnostic templates**: `diagnostic_summary` and `diagnostic_detail`
+  - Used when enriching framework-generated diagnostics (e.g., via `EnrichAppend`).
+
+> **Note:** All output is a diagnostic. The template name refers to the input type (error vs. diagnostic).
+
+**Function-to-template mapping:**
+- `AddError` and `Append` use `error_summary` and `error_detail`.
+- `EnrichAppend` uses `diagnostic_summary` and `diagnostic_detail`.
+
+If the relevant templates are not defined, smarterr falls back to the original error or diagnostic content.
+
 ## Why smarterr?
 
 - **For developers:**
@@ -75,9 +92,11 @@ smarterr uses configuration—not code changes—to split an incoming error into
 2. **Call smarterr in your error handling:**
 
    ```go
-   smarterr.AddError(ctx, diags, err, "id", id)
+   smarterr.AddError(ctx, diags, err, "id", id) // uses error_summary/error_detail
    // or for SDK diagnostics:
-   diags = smarterr.Append(ctx, diags, err, "id", id)
+   diags = smarterr.Append(ctx, diags, err, "id", id) // uses error_summary/error_detail
+   // or to enrich framework diagnostics:
+   smarterr.EnrichAppend(ctx, &diags, incoming, "id", id) // uses diagnostic_summary/diagnostic_detail
    ```
 
 ### CLI Usage (Work in Progress)
@@ -106,6 +125,10 @@ template "error_summary" {
   format = "{{.happening}} {{.service}} {{.resource}} ({{.identifier}}): {{.error}}"
 }
 
+template "diagnostic_summary" {
+  format = "{{.happening}} {{.service}} {{.resource}}: {{.diag.summary}}"
+}
+
 token "happening" {
   stack_matches = [
     "create",
@@ -129,6 +152,14 @@ token "error" {
   transforms = [
     "clean_aws_error"
   ]
+}
+
+token "diag" {
+  source = "diagnostic"
+  field_transforms = {
+    summary = ["upper"]
+    detail  = ["lower"]
+  }
 }
 
 stack_match "create" {

--- a/README.md
+++ b/README.md
@@ -159,6 +159,45 @@ transform "clean_aws_error" {
 
 ---
 
+## Diagnostic Enrichment & Structured Tokens
+
+smarterr supports config-driven enrichment of both errors and framework-generated diagnostics (such as value conversion errors in Terraform Plugin Framework) using a structured diagnostic token.
+
+### Diagnostic Token Usage
+
+- Define a token with `source = "diagnostic"` to expose a structured token with fields (e.g., `.diag.summary`, `.diag.detail`, `.diag.severity`).
+- Use `field_transforms` to apply transforms to individual fields of the diagnostic token.
+
+Example:
+
+```hcl
+token "diag" {
+  source = "diagnostic"
+  field_transforms = {
+    summary = ["upper"]
+    detail  = ["lower"]
+  }
+}
+```
+
+In your template, access fields as `{{.diag.summary}}`, `{{.diag.detail}}`, etc.
+
+Example template:
+
+```hcl
+template "diagnostic_summary" {
+  format = "{{.happening}} {{.service}} {{.resource}}: {{.diag.summary}}"
+}
+
+template "diagnostic_detail" {
+  format = "ID: {{.identifier}}\nCause: {{.diag.detail}}"
+}
+```
+
+This enables actionable, context-rich diagnostics for both errors and framework-generated issues, all managed declaratively via config.
+
+---
+
 ## Learn More
 
 - [Full Config Schema](docs/schema.md)

--- a/cmd/smarterr/config.go
+++ b/cmd/smarterr/config.go
@@ -151,9 +151,6 @@ func convertConfigToHCL(cfg *internal.Config) ([]byte, error) {
 		if sm.CalledFrom != "" {
 			b.SetAttributeValue("called_from", cty.StringVal(sm.CalledFrom))
 		}
-		if sm.CalledAfter != "" {
-			b.SetAttributeValue("called_after", cty.StringVal(sm.CalledAfter))
-		}
 		b.SetAttributeValue("display", cty.StringVal(sm.Display))
 	}
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,41 @@
+# smarterr Documentation
+
+Welcome to the documentation for **smarterr**—a declarative, layered, and maintainable error handling library for Go. smarterr lets you standardize, enrich, and centrally manage error messages and diagnostics across large codebases, all driven by configuration instead of scattered code changes.
+
+## What is smarterr?
+smarterr is a Go library that:
+- Centralizes error formatting and diagnostics using config files (not code changes)
+- Supports layered, directory-based configuration for scalable error management
+- Produces actionable, user-friendly error summaries, details, and logs
+- Never obscures the original error, even if config is missing or broken
+
+## Key Features
+- **Declarative error output:** Define error messages, details, and logs in config files
+- **Layered configs:** Merge global, parent, and local configs for flexible control
+- **Diagnostic enrichment:** Enhance framework-generated diagnostics with context and suggestions
+- **Safe fallbacks:** Always show the original error if config or templates fail
+
+## Where to Start
+If you're new to smarterr, start with these docs:
+
+- [**API Reference**](api.md):
+  - How to use smarterr in your Go code (setup, error wrapping, appending, logger integration)
+- [**Config Schema**](schema.md):
+  - Full reference for all config blocks, fields, and options in `smarterr.hcl`
+- [**Layered Configs & Merging**](layering.md):
+  - How smarterr discovers, merges, and applies configs across directories
+- [**Diagnostics & Fallbacks**](diagnostics.md):
+  - How smarterr handles missing/broken config and ensures errors are never lost
+
+## Example Use Cases
+- Standardize error output for all resources in a Terraform provider
+- Add actionable suggestions to framework diagnostics without code changes
+- Evolve error messages and formatting centrally, even in large codebases
+
+## More Information
+- For a high-level overview and quickstart, see the root [README.md](../README.md)
+- For advanced config examples, see the [Config Schema](schema.md)
+
+---
+
+**smarterr** helps you deliver better error messages, faster diagnostics, and safer refactoring—at scale.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,23 @@ smarterr is a Go library that:
 - Produces actionable, user-friendly error summaries, details, and logs
 - Never obscures the original error, even if config is missing or broken
 
+## Template Types and Usage
+
+smarterr supports two main template types for customizing diagnostic output:
+
+- **Error templates**: `error_summary` and `error_detail`
+  - Used when formatting diagnostics from Go errors (e.g., via `AddError` or `Append`).
+- **Diagnostic templates**: `diagnostic_summary` and `diagnostic_detail`
+  - Used when enriching framework-generated diagnostics (e.g., via `EnrichAppend`).
+
+> **Note:** All output is a diagnostic. The template name refers to the input type (error vs. diagnostic).
+
+**Function-to-template mapping:**
+- `AddError` and `Append` use `error_summary` and `error_detail`.
+- `EnrichAppend` uses `diagnostic_summary` and `diagnostic_detail`.
+
+If the relevant templates are not defined, smarterr falls back to the original error or diagnostic content.
+
 ## Key Features
 - **Declarative error output:** Define error messages, details, and logs in config files
 - **Layered configs:** Merge global, parent, and local configs for flexible control

--- a/docs/api.md
+++ b/docs/api.md
@@ -113,7 +113,7 @@ if err != nil {
 return smarterr.Errorf("unexpected result for alarm %q", name)
 ```
 
-The resulting error can be passed directly to `smarterr.AppendSDK` or `smarterr.AppendFW` for config-driven formatting and diagnostics. The captured stack is used for advanced stack matching and template tokens.
+The resulting error can be passed directly to `smarterr.Append` or `smarterr.AddError` for config-driven formatting and diagnostics. The captured stack is used for advanced stack matching and template tokens.
 
 ### Error Type
 
@@ -130,19 +130,19 @@ type Error struct {
 
 ## Error Appending
 
-### AppendFW
+### AddError
 
 ```go
-func AppendFW(ctx context.Context, diags fwdiag.Diagnostics, err error, keyvals ...any)
+func AddError(ctx context.Context, diags fwdiag.Diagnostics, err error, keyvals ...any)
 ```
-Appends a formatted error to Terraform Plugin Framework diagnostics.
+Adds a formatted error to Terraform Plugin Framework diagnostics.
 
-### AppendSDK
+### Append
 
 ```go
-func AppendSDK(ctx context.Context, diags sdkdiag.Diagnostics, err error, keyvals ...any) sdkdiag.Diagnostics
+func Append(ctx context.Context, diags sdkdiag.Diagnostics, err error, keyvals ...any) sdkdiag.Diagnostics
 ```
-Appends a formatted error to Terraform Plugin SDK diagnostics and returns the updated diagnostics slice.
+Adds a formatted error to Terraform Plugin SDK diagnostics and returns the updated diagnostics slice.
 
 ---
 
@@ -162,13 +162,13 @@ smarterr uses special template names in your config to control where output goes
 - `error_detail`: Rendered to the diagnostics detail (the expanded/collapsed error details).
 - `log_error`, `log_warn`, `log_info`: Rendered to the user-facing logger (e.g., tflog or Go log) at the corresponding level.
 
-You reference these templates by name in your config. smarterr will automatically use them when you call `AppendFW` or `AppendSDK`.
+You reference these templates by name in your config. smarterr will automatically use them when you call `Append` or `AddError`.
 
 ### Example: API Call + Config
 
 **Go code:**
 ```go
-smarterr.AppendSDK(ctx, diags, err, "id", id)
+smarterr.Append(ctx, diags, err, "id", id)
 ```
 
 **Config (HCL):**

--- a/docs/api.md
+++ b/docs/api.md
@@ -194,6 +194,45 @@ See [Full Config Schema](schema.md) for all template and token options.
 
 ---
 
+## Diagnostic Token Support
+
+smarterr supports config-driven enrichment of both errors and framework-generated diagnostics (e.g., value conversion errors in Terraform Plugin Framework) via a special diagnostic token source.
+
+### Diagnostic Token
+
+- Use `source = "diagnostic"` in a token block to expose a structured token with fields (e.g., `.diag.summary`, `.diag.detail`, `.diag.severity`).
+- Use `field_transforms` to apply transforms to individual fields of the diagnostic token.
+
+#### Example
+
+```hcl
+token "diag" {
+  source = "diagnostic"
+  field_transforms = {
+    summary = ["upper"]
+    detail  = ["lower"]
+  }
+}
+```
+
+In your template, access fields as `{{.diag.summary}}`, `{{.diag.detail}}`, etc.
+
+#### Template Example
+
+```hcl
+template "diagnostic_summary" {
+  format = "{{.happening}} {{.service}} {{.resource}}: {{.diag.summary}}"
+}
+
+template "diagnostic_detail" {
+  format = "ID: {{.identifier}}\nCause: {{.diag.detail}}"
+}
+```
+
+- The diagnostic token is populated from the runtime (e.g., framework diagnostic context) and can be enriched and transformed via config.
+
+---
+
 ## Assert
 
 ```go

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,6 +4,25 @@ This document describes the public Go API for smarterr, including configuration,
 
 ---
 
+## Template Types and Usage
+
+smarterr supports two main template types for customizing diagnostic output:
+
+- **Error templates**: `error_summary` and `error_detail`
+  - Used when formatting diagnostics from Go errors (e.g., via `AddError` or `Append`).
+- **Diagnostic templates**: `diagnostic_summary` and `diagnostic_detail`
+  - Used when enriching framework-generated diagnostics (e.g., via `EnrichAppend`).
+
+> **Note:** All output is a diagnostic. The template name refers to the input type (error vs. diagnostic).
+
+**Function-to-template mapping:**
+- `AddError` and `Append` use `error_summary` and `error_detail`.
+- `EnrichAppend` uses `diagnostic_summary` and `diagnostic_detail`.
+
+If the relevant templates are not defined, smarterr falls back to the original error or diagnostic content.
+
+---
+
 ## Filesystem Setup
 
 smarterr uses a virtual filesystem for config discovery. You must set this at startup:

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,5 +1,10 @@
 # smarterr Diagnostics & Fallbacks
 
+> **Template Types and Usage:**
+> - `AddError` and `Append` use `error_summary` and `error_detail` templates (for Go errors).
+> - `EnrichAppend` uses `diagnostic_summary` and `diagnostic_detail` templates (for framework diagnostics).
+> - All output is a diagnostic; the template name refers to the input type (error vs. diagnostic).
+
 smarterr is designed to never obscure the main error. If config is missing, broken, or a template fails, smarterr:
 
 - Always includes the original error in the output.

--- a/docs/layering.md
+++ b/docs/layering.md
@@ -1,5 +1,10 @@
 # smarterr Layered Configs & Merging
 
+> **Template Types and Usage:**
+> - `AddError` and `Append` use `error_summary` and `error_detail` templates (for Go errors).
+> - `EnrichAppend` uses `diagnostic_summary` and `diagnostic_detail` templates (for framework diagnostics).
+> - All output is a diagnostic; the template name refers to the input type (error vs. diagnostic).
+
 smarterr supports layered, directory-based configuration. This allows you to define global, parent, and subdirectory configs that are automatically merged for each error site.
 
 ---

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -8,7 +8,7 @@ This document describes the full configuration schema for smarterr, including al
 
 smarterr supports two types of call stack sources for stack matching and tokens:
 
-- **Live Call Stack**: The stack at the point where `AppendSDK`/`AppendFW` is called. Use with `source = "call_stack"`.
+- **Live Call Stack**: The stack at the point where `Append`/`AddError` is called. Use with `source = "call_stack"`.
 - **Captured Call Stack**: The stack captured at the point where `NewError` or `Errorf` is called. Use with `source = "error_stack"`.
 
 This distinction allows you to match on either the reporting site or the original error site, enabling more precise and context-aware diagnostics.
@@ -129,7 +129,7 @@ Reference:
 token "name" {
   parameter    = "..."   # Reference a parameter
   context      = "..."   # Pull from context.Context
-  arg          = "..."   # Pull from AppendSDK/FW args
+  arg          = "..."   # Pull from Append/AddError args
   source       = "..."   # "parameter" | "context" | "arg" | "error" | "call_stack" | "error_stack" | "hints" | "diagnostic"
   stack_matches = [ ... ] # Names of stack_match blocks
   transforms   = [ ... ] # Names of transform blocks (applies to string tokens)

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -4,6 +4,31 @@ This document describes the full configuration schema for smarterr, including al
 
 ---
 
+## Call Stack Sources: Live vs Captured
+
+smarterr supports two types of call stack sources for stack matching and tokens:
+
+- **Live Call Stack**: The stack at the point where `AppendSDK`/`AppendFW` is called. Use with `source = "call_stack"`.
+- **Captured Call Stack**: The stack captured at the point where `NewError` or `Errorf` is called. Use with `source = "error_stack"`.
+
+This distinction allows you to match on either the reporting site or the original error site, enabling more precise and context-aware diagnostics.
+
+### Example
+
+```hcl
+token "happening" {
+  source = "call_stack"
+  stack_matches = ["create", "read", "update", "delete"]
+}
+
+token "subaction" {
+  source = "error_stack"
+  stack_matches = ["wait", "find", "set"]
+}
+```
+
+---
+
 ## Top-Level Blocks
 
 - `smarterr` (optional): Behavioral settings for error formatting and diagnostics.
@@ -83,11 +108,14 @@ token "name" {
   parameter    = "..."   # Reference a parameter
   context      = "..."   # Pull from context.Context
   arg          = "..."   # Pull from AppendSDK/FW args
-  source       = "..."   # "parameter" | "context" | "arg" | "error" | "call_stack" | "hints"
+  source       = "..."   # "parameter" | "context" | "arg" | "error" | "call_stack" | "error_stack" | "hints"
   stack_matches = [ ... ] # Names of stack_match blocks
   transforms   = [ ... ] # Names of transform blocks
 }
 ```
+
+- `source = "call_stack"`: Uses the live stack at the point of error reporting.
+- `source = "error_stack"`: Uses the stack captured at the point of error creation (via `NewError`/`Errorf`).
 
 Example:
 
@@ -267,3 +295,4 @@ transform "clean_aws_error" {
 - All blocks can be layered and merged across directories.
 - See [docs/layering.md](layering.md) for details on config discovery and merging.
 - See [docs/diagnostics.md](diagnostics.md) for fallback and diagnostics behavior.
+- For advanced stack matching, see the distinction between `call_stack` and `error_stack` sources above.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -99,6 +99,28 @@ template "log_error" {
 }
 ```
 
+### Template Types
+
+smarterr supports the following template types:
+
+- `error_summary`: Rendered for error summary (main error message).
+- `error_detail`: Rendered for error detail (expanded/collapsed details).
+- `diagnostic_summary`: Rendered for framework/diagnostic summary (e.g., value conversion errors).
+- `diagnostic_detail`: Rendered for framework/diagnostic detail.
+- `log_error`, `log_warn`, `log_info`: Rendered to the user-facing logger at the corresponding level.
+
+Reference:
+
+```
+template "diagnostic_summary" {
+  format = "{{.happening}} {{.service}} {{.resource}}: {{.original_summary}}"
+}
+
+template "diagnostic_detail" {
+  format = "ID: {{.identifier}}\nOriginal: {{.original_detail}}\nContext: {{.happening}} {{.service}} {{.resource}}"
+}
+```
+
 ### `token`
 
 Reference:

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -117,88 +117,6 @@ token "name" {
 - `source = "call_stack"`: Uses the live stack at the point of error reporting.
 - `source = "error_stack"`: Uses the stack captured at the point of error creation (via `NewError`/`Errorf`).
 
-Example:
-
-```hcl
-token "happening" {
-  stack_matches = [
-    "create",
-    "read",
-    "update",
-    "delete",
-    "read_set",
-    "read_find",
-    "create_wait"
-  ]
-}
-
-token "service" {
-  parameter = "service"
-}
-
-token "resource" {
-  context = "resource_name"
-}
-
-token "identifier" {
-  arg = "id"
-}
-
-token "clean_error" {
-  source = "error"
-  transforms = [
-    "clean_aws_error"
-  ]
-}
-
-token "error" {
-  source = "error"
-}
-
-token "suggest" {
-  source = "hints"
-}
-```
-
-### `parameter`
-
-Reference:
-
-```
-parameter "name" {
-  value = "..."
-}
-```
-
-Example:
-
-```hcl
-parameter "service" {
-  value = "CloudWatch"
-}
-```
-
-### `hint`
-
-Reference:
-
-```
-hint "name" {
-  error_contains = "..."   # Substring match on error
-  regex_match    = "..."   # Regex match on error
-  suggestion     = "..."   # Text to show if matched
-}
-```
-
-Example:
-
-```hcl
-hint "example_hint" {
-  error_contains = "InvalidParameterCombination"
-  suggestion     = "Check your AWS resource parameters."
-}
-```
-
 ### `stack_match`
 
 Reference:
@@ -206,7 +124,6 @@ Reference:
 ```
 stack_match "name" {
   called_from  = "..."   # Regex for function name
-  called_after = "..."   # Regex for previous function in stack
   display      = "..."   # Value to use if matched
 }
 ```
@@ -234,22 +151,19 @@ stack_match "delete" {
   display     = "deleting"
 }
 
-stack_match "read_set" {
-  called_after = "Set"
-  called_from  = "resource[a-zA-Z0-9]*Read"
-  display      = "setting during read"
+stack_match "wait" {
+  called_from = "wait.*"
+  display     = "waiting during operation"
 }
 
-stack_match "read_find" {
-  called_after = "find.*"
-  called_from  = "resource[a-zA-Z0-9]*Read"
-  display      = "finding during read"
+stack_match "find" {
+  called_from = "find.*"
+  display     = "finding during operation"
 }
 
-stack_match "create_wait" {
-  called_after = "wait.*"
-  called_from  = "resource[a-zA-Z0-9]*Create"
-  display      = "waiting during creation"
+stack_match "set" {
+  called_from = "Set"
+  display     = "setting during operation"
 }
 ```
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -4,6 +4,25 @@ This document describes the full configuration schema for smarterr, including al
 
 ---
 
+## Template Types and Usage
+
+smarterr supports two main template types for customizing diagnostic output:
+
+- **Error templates**: `error_summary` and `error_detail`
+  - Used when formatting diagnostics from Go errors (e.g., via `AddError` or `Append`).
+- **Diagnostic templates**: `diagnostic_summary` and `diagnostic_detail`
+  - Used when enriching framework-generated diagnostics (e.g., via `EnrichAppend`).
+
+> **Note:** All output is a diagnostic. The template name refers to the input type (error vs. diagnostic).
+
+**Function-to-template mapping:**
+- `AddError` and `Append` use `error_summary` and `error_detail`.
+- `EnrichAppend` uses `diagnostic_summary` and `diagnostic_detail`.
+
+If the relevant templates are not defined, smarterr falls back to the original error or diagnostic content.
+
+---
+
 ## Call Stack Sources: Live vs Captured
 
 smarterr supports two types of call stack sources for stack matching and tokens:

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -130,14 +130,35 @@ token "name" {
   parameter    = "..."   # Reference a parameter
   context      = "..."   # Pull from context.Context
   arg          = "..."   # Pull from AppendSDK/FW args
-  source       = "..."   # "parameter" | "context" | "arg" | "error" | "call_stack" | "error_stack" | "hints"
+  source       = "..."   # "parameter" | "context" | "arg" | "error" | "call_stack" | "error_stack" | "hints" | "diagnostic"
   stack_matches = [ ... ] # Names of stack_match blocks
-  transforms   = [ ... ] # Names of transform blocks
+  transforms   = [ ... ] # Names of transform blocks (applies to string tokens)
+  field_transforms = {   # (optional) For structured tokens like diagnostic, apply transforms to fields
+    summary  = ["upper"]
+    detail   = ["lower"]
+    # ...
+  }
 }
 ```
 
 - `source = "call_stack"`: Uses the live stack at the point of error reporting.
 - `source = "error_stack"`: Uses the stack captured at the point of error creation (via `NewError`/`Errorf`).
+- `source = "diagnostic"`: Exposes a structured token with fields (e.g., `.diag.summary`, `.diag.detail`, `.diag.severity`).
+- `field_transforms`: Map of field name to list of transform names, applied to each field of a structured token.
+
+Example:
+
+```hcl
+token "diag" {
+  source = "diagnostic"
+  field_transforms = {
+    summary = ["upper"]
+    detail  = ["lower"]
+  }
+}
+```
+
+In your template, access fields as `{{.diag.summary}}`, `{{.diag.detail}}`, etc.
 
 ### `stack_match`
 

--- a/error.go
+++ b/error.go
@@ -1,0 +1,85 @@
+package smarterr
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+)
+
+// Error is the enriched smarterr error type.
+// It wraps a base error and includes structured annotations
+// that can be used by AppendSDK/FW to construct clear, user-friendly diagnostics.
+type Error struct {
+	Err           error             // The original or wrapped error
+	Message       string            // Optional developer-provided message (from Errorf)
+	Annotations   map[string]string // Arbitrary key-value annotations (e.g., subaction, resource_id)
+	CapturedStack []runtime.Frame   // Captured call stack for stack matching
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return e.Err.Error()
+}
+
+// Unwrap returns the underlying error.
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
+// Stack returns the captured call stack frames.
+func (e *Error) Stack() []runtime.Frame {
+	return e.CapturedStack
+}
+
+// NewError wraps an existing error with smarterr metadata derived from the call stack.
+// It automatically annotates the error with context-aware information (e.g., sub-action)
+// without requiring developer input, reducing fragility and promoting consistent error enrichment.
+//
+// Use NewError at the site where an error is first returned or recognized.
+// The resulting error can be passed directly to smarterr.AppendSDK or smarterr.AppendFW
+// without needing manual WithField-style annotation.
+//
+// Example:
+//
+//	return nil, smarterr.NewError(err)
+func NewError(err error) error {
+	if err == nil {
+		return nil
+	}
+	stack := captureStack(3) // skip 3 to get the caller of NewError
+	return &Error{
+		Err:           err,
+		Annotations:   map[string]string{},
+		CapturedStack: stack,
+	}
+}
+
+// Errorf formats according to a format specifier and returns a smarterr-enriched error.
+// It behaves like fmt.Errorf, but also captures contextual metadata based on the call site.
+// This ensures consistent DX and structured diagnostics with minimal developer effort.
+//
+// Example:
+//
+//	return smarterr.Errorf("unexpected result for alarm %q", name)
+func Errorf(format string, args ...any) error {
+	msg := fmt.Sprintf(format, args...)
+	stack := captureStack(3) // skip 3 to get the caller of Errorf
+	return &Error{
+		Err:           errors.New(msg),
+		Message:       msg,
+		Annotations:   map[string]string{},
+		CapturedStack: stack,
+	}
+}
+
+// Assert wraps a call returning (T, error) with smarterr.NewError on failure.
+// Go doesn't yet support generics-based tuple unpacking, so this form works well for now.
+func Assert[T any](val T, err error) (T, error) {
+	if err != nil {
+		return val, NewError(err)
+	}
+	return val, nil
+}

--- a/error.go
+++ b/error.go
@@ -8,7 +8,7 @@ import (
 
 // Error is the enriched smarterr error type.
 // It wraps a base error and includes structured annotations
-// that can be used by AppendSDK/FW to construct clear, user-friendly diagnostics.
+// that can be used by Append or AddError to construct clear, user-friendly diagnostics.
 type Error struct {
 	Err           error             // The original or wrapped error
 	Message       string            // Optional developer-provided message (from Errorf)
@@ -39,7 +39,7 @@ func (e *Error) Stack() []runtime.Frame {
 // without requiring developer input, reducing fragility and promoting consistent error enrichment.
 //
 // Use NewError at the site where an error is first returned or recognized.
-// The resulting error can be passed directly to smarterr.AppendSDK or smarterr.AppendFW
+// The resulting error can be passed directly to smarterr.Append or smarterr.AddError
 // without needing manual WithField-style annotation.
 //
 // Example:

--- a/internal/runtime.go
+++ b/internal/runtime.go
@@ -194,7 +194,7 @@ func applyReplace(value string, step TransformStep) string {
 // Resolve takes a token and resolves it based on the runtime information.
 // It supports various source types such as parameters, context values,
 // error inspection, call stack inspection, and runtime arguments.
-func (t *Token) Resolve(ctx context.Context, rt *Runtime) string {
+func (t *Token) Resolve(ctx context.Context, rt *Runtime) any {
 	Debugf("Resolving token: %s, source: %s, parameter: %v, context: %v, arg: %v, stack_matches: %v",
 		t.Name, t.Source, t.Parameter, t.Context, t.Arg, t.StackMatches)
 	// Infer source if not set
@@ -214,11 +214,34 @@ func (t *Token) Resolve(ctx context.Context, rt *Runtime) string {
 		}
 	}
 
-	var value string
-
 	switch source {
+	case "diagnostic":
+		diag, ok := rt.Args["diagnostic"].(map[string]string)
+		if !ok || diag == nil {
+			Debugf("Fallback for token %q: diagnostic info not found in runtime args", t.Name)
+			return map[string]any{
+				"summary":  fallbackMessage(rt.Config, t.Name+".summary", "diagnostic summary not found"),
+				"detail":   fallbackMessage(rt.Config, t.Name+".detail", "diagnostic detail not found"),
+				"severity": fallbackMessage(rt.Config, t.Name+".severity", "diagnostic severity not found"),
+			}
+		}
+		result := make(map[string]any)
+		for k, v := range diag {
+			if t.FieldTransforms != nil {
+				if transforms, ok := t.FieldTransforms[k]; ok && len(transforms) > 0 {
+					val := v
+					for _, tname := range transforms {
+						val = rt.applyTransformByName(tname, val)
+					}
+					result[k] = val
+					continue
+				}
+			}
+			result[k] = v
+		}
+		return result
 	case "parameter":
-		// Look up the parameter by name.
+		var value string
 		if t.Parameter == nil {
 			Debugf("Fallback for token %q: token.Parameter is nil", t.Name)
 			value = fallbackMessage(rt.Config, t.Name, "token.Parameter is nil")
@@ -234,9 +257,12 @@ func (t *Token) Resolve(ctx context.Context, rt *Runtime) string {
 				value = fallbackMessage(rt.Config, t.Name, "parameter not found in config")
 			}
 		}
-
+		if t.Transforms != nil && len(t.Transforms) > 0 {
+			value = rt.applyTransforms(t, value)
+		}
+		return value
 	case "context":
-		// Extract value from context by key.
+		var value string
 		if t.Context == nil {
 			Debugf("Fallback for token %q: token.Context is nil", t.Name)
 			value = fallbackMessage(rt.Config, t.Name, "token.Context is nil")
@@ -249,12 +275,12 @@ func (t *Token) Resolve(ctx context.Context, rt *Runtime) string {
 				value = fmt.Sprintf("%v", val)
 			}
 		}
-
+		if t.Transforms != nil && len(t.Transforms) > 0 {
+			value = rt.applyTransforms(t, value)
+		}
+		return value
 	case "call_stack":
-		// "call_stack" is for the live stack when AppendSDK or AppendFW is called, as
-		// opposed to the "error_stack" which is for the captured stack from smarterr.Error.
-
-		// Filter StackMatches based on Token.StackMatches
+		var value string
 		var filteredStackMatches []StackMatch
 		for _, name := range t.StackMatches {
 			for _, sm := range rt.Config.StackMatches {
@@ -264,14 +290,11 @@ func (t *Token) Resolve(ctx context.Context, rt *Runtime) string {
 				}
 			}
 		}
-
-		// Gather the call stack
-		frames, err := gatherCallStack(3) // Skip 3 frames to exclude runtime.Callers, gatherCallStack, and Resolve
+		frames, err := gatherCallStack(3)
 		if err != nil {
 			Debugf("Fallback for token %q: call stack unavailable", t.Name)
 			value = fallbackMessage(rt.Config, t.Name, "call stack unavailable")
 		} else {
-			// Process the filtered stack matches
 			display, err := processStackMatches(filteredStackMatches, frames)
 			if err != nil {
 				Debugf("Fallback for token %q: stack match error: %s", t.Name, err.Error())
@@ -283,9 +306,12 @@ func (t *Token) Resolve(ctx context.Context, rt *Runtime) string {
 				value = fallbackMessage(rt.Config, t.Name, "no stack match found")
 			}
 		}
-
+		if t.Transforms != nil && len(t.Transforms) > 0 {
+			value = rt.applyTransforms(t, value)
+		}
+		return value
 	case "error_stack":
-		// Use the captured stack from smarterr.Error if available
+		var value string
 		var filteredStackMatches []StackMatch
 		for _, name := range t.StackMatches {
 			for _, sm := range rt.Config.StackMatches {
@@ -316,8 +342,12 @@ func (t *Token) Resolve(ctx context.Context, rt *Runtime) string {
 				value = fallbackMessage(rt.Config, t.Name, "no error_stack match found")
 			}
 		}
-
+		if t.Transforms != nil && len(t.Transforms) > 0 {
+			value = rt.applyTransforms(t, value)
+		}
+		return value
 	case "error":
+		var value string
 		Debugf("Resolving error token: %s, err: %s", t.Name, rt.Error)
 		if rt.Error == nil {
 			Debugf("Fallback for token %q: rt.Error is nil", t.Name)
@@ -325,9 +355,12 @@ func (t *Token) Resolve(ctx context.Context, rt *Runtime) string {
 		} else {
 			value = fmt.Sprintf("%s", rt.Error)
 		}
-
+		if t.Transforms != nil && len(t.Transforms) > 0 {
+			value = rt.applyTransforms(t, value)
+		}
+		return value
 	case "arg":
-		// Pull from runtime arguments.
+		var value string
 		if t.Arg == nil {
 			Debugf("Fallback for token %q: token.Arg is nil", t.Name)
 			value = fallbackMessage(rt.Config, t.Name, "token.Arg is nil")
@@ -340,8 +373,12 @@ func (t *Token) Resolve(ctx context.Context, rt *Runtime) string {
 				value = fmt.Sprintf("%v", argVal)
 			}
 		}
-
+		if t.Transforms != nil && len(t.Transforms) > 0 {
+			value = rt.applyTransforms(t, value)
+		}
+		return value
 	case "hints":
+		var value string
 		Debugf("Resolving hints token: %s", t.Name)
 		if rt.Error != nil {
 			value = resolveHints(rt.Error.Error(), rt.Config, nil)
@@ -350,16 +387,51 @@ func (t *Token) Resolve(ctx context.Context, rt *Runtime) string {
 			Debugf("Fallback for token %q: no matching hint found", t.Name)
 			value = fallbackMessage(rt.Config, t.Name, "no matching hint found")
 		}
-
+		if t.Transforms != nil && len(t.Transforms) > 0 {
+			value = rt.applyTransforms(t, value)
+		}
+		return value
 	default:
+		var value string
 		Debugf("Fallback for token %q: unknown token source", t.Name)
 		value = fallbackMessage(rt.Config, t.Name, "unknown token source")
+		if t.Transforms != nil && len(t.Transforms) > 0 {
+			value = rt.applyTransforms(t, value)
+		}
+		return value
 	}
+}
 
-	Debugf("Resolved token %q with source %q: %q", t.Name, source, value)
-	// Only apply transforms if t.Transforms is non-nil and non-empty
-	if t.Transforms != nil && len(t.Transforms) > 0 {
-		value = rt.applyTransforms(t, value)
+// Helper to apply a named transform to a value (for field transforms)
+func (rt *Runtime) applyTransformByName(name, value string) string {
+	if rt.Config == nil {
+		return value
+	}
+	for i := range rt.Config.Transforms {
+		if rt.Config.Transforms[i].Name == name {
+			for _, step := range rt.Config.Transforms[i].Steps {
+				switch step.Type {
+				case "strip_prefix":
+					value = applyStripPrefix(value, step)
+				case "strip_suffix":
+					value = applyStripSuffix(value, step)
+				case "remove":
+					value = applyRemove(value, step)
+				case "replace":
+					value = applyReplace(value, step)
+				case "trim_space":
+					value = strings.TrimSpace(value)
+				case "fix_space":
+					value = strings.TrimSpace(value)
+					value = regexp.MustCompile(`\s+`).ReplaceAllString(value, " ")
+				case "lower":
+					value = strings.ToLower(value)
+				case "upper":
+					value = strings.ToUpper(value)
+				}
+			}
+			break
+		}
 	}
 	return value
 }

--- a/internal/runtime_test.go
+++ b/internal/runtime_test.go
@@ -336,13 +336,13 @@ func TestTokenResolve_HintsSource(t *testing.T) {
 	}
 }
 
-func TestProcessStackMatches_SpecificityPreference(t *testing.T) {
+func TestProcessStackMatches_CalledFromPreference(t *testing.T) {
 	matches := []StackMatch{
 		{Name: "create", CalledFrom: "resource[a-zA-Z0-9]*Create", Display: "creating"},
 		{Name: "read", CalledFrom: "resource[a-zA-Z0-9]*Read", Display: "reading"},
-		{Name: "create_wait", CalledFrom: "resource[a-zA-Z0-9]*Create", CalledAfter: "wait.*", Display: "waiting during creation"},
-		{Name: "read_find", CalledFrom: "resource[a-zA-Z0-9]*Read", CalledAfter: "find.*", Display: "finding during read"},
-		{Name: "read_set", CalledFrom: "resource[a-zA-Z0-9]*Read", CalledAfter: "Set", Display: "setting during read"},
+		{Name: "wait", CalledFrom: "wait.*", Display: "waiting during operation"},
+		{Name: "find", CalledFrom: "find.*", Display: "finding during operation"},
+		{Name: "set", CalledFrom: "Set", Display: "setting during operation"},
 	}
 
 	tests := []struct {
@@ -351,32 +351,27 @@ func TestProcessStackMatches_SpecificityPreference(t *testing.T) {
 		want   string
 	}{
 		{
-			name:   "most specific: create_wait",
-			frames: []runtime.Frame{{Function: "resourceFooCreate"}, {Function: "waitForSomething"}},
-			want:   "waiting during creation",
+			name:   "match wait subaction",
+			frames: []runtime.Frame{{Function: "waitForSomething"}, {Function: "resourceFooCreate"}},
+			want:   "waiting during operation",
 		},
 		{
-			name:   "most specific: read_find",
-			frames: []runtime.Frame{{Function: "resourceFooRead"}, {Function: "findBar"}},
-			want:   "finding during read",
+			name:   "match find subaction",
+			frames: []runtime.Frame{{Function: "findBar"}, {Function: "resourceFooRead"}},
+			want:   "finding during operation",
 		},
 		{
-			name:   "most specific: read_set",
-			frames: []runtime.Frame{{Function: "resourceBarRead"}, {Function: "Set"}},
-			want:   "setting during read",
+			name:   "match set subaction",
+			frames: []runtime.Frame{{Function: "Set"}, {Function: "resourceBarRead"}},
+			want:   "setting during operation",
 		},
 		{
-			name:   "fallback to called_after only",
-			frames: []runtime.Frame{{Function: "foo"}, {Function: "Set"}},
-			want:   "",
-		},
-		{
-			name:   "fallback to called_from only",
+			name:   "fallback to create",
 			frames: []runtime.Frame{{Function: "resourceFooCreate"}},
 			want:   "creating",
 		},
 		{
-			name:   "fallback to called_from only (read)",
+			name:   "fallback to read",
 			frames: []runtime.Frame{{Function: "resourceFooRead"}},
 			want:   "reading",
 		},

--- a/internal/types.go
+++ b/internal/types.go
@@ -74,8 +74,7 @@ type Hint struct {
 }
 
 type StackMatch struct {
-	Name        string `hcl:"name,label"`
-	CalledFrom  string `hcl:"called_from,optional"`
-	CalledAfter string `hcl:"called_after,optional"`
-	Display     string `hcl:"display"`
+	Name       string `hcl:"name,label"`
+	CalledFrom string `hcl:"called_from,optional"`
+	Display    string `hcl:"display"`
 }

--- a/internal/types.go
+++ b/internal/types.go
@@ -50,15 +50,16 @@ type Transform struct {
 
 // Token represents a token in the configuration, which can be used for error message formatting.
 type Token struct {
-	Name         string   `hcl:"name,label"`
-	Source       string   `hcl:"source,optional"`
-	Parameter    *string  `hcl:"parameter,optional"`
-	StackMatches []string `hcl:"stack_matches,optional"`
-	Arg          *string  `hcl:"arg,optional"`
-	Context      *string  `hcl:"context,optional"`
-	Pattern      *string  `hcl:"pattern,optional"`
-	Replace      *string  `hcl:"replace,optional"`
-	Transforms   []string `hcl:"transforms,optional"`
+	Name            string              `hcl:"name,label"`
+	Source          string              `hcl:"source,optional"`
+	Parameter       *string             `hcl:"parameter,optional"`
+	StackMatches    []string            `hcl:"stack_matches,optional"`
+	Arg             *string             `hcl:"arg,optional"`
+	Context         *string             `hcl:"context,optional"`
+	Pattern         *string             `hcl:"pattern,optional"`
+	Replace         *string             `hcl:"replace,optional"`
+	Transforms      []string            `hcl:"transforms,optional"`
+	FieldTransforms map[string][]string `hcl:"field_transforms,optional"`
 }
 
 type Parameter struct {

--- a/smarterr.go
+++ b/smarterr.go
@@ -10,7 +10,9 @@ import (
 )
 
 const (
-	ID = "id"
+	ID           = "id"
+	ResourceName = "resource_name"
+	ServiceName  = "service_name"
 )
 
 // Re-export internal.Debugf for internal debugging

--- a/smarterr.go
+++ b/smarterr.go
@@ -133,10 +133,10 @@ func appendCommon(ctx context.Context, add func(summary, detail string), err err
 // It wraps a base error and includes structured annotations
 // that can be used by AppendSDK/FW to construct clear, user-friendly diagnostics.
 type Error struct {
-	Err         error             // The original or wrapped error
-	Message     string            // Optional developer-provided message (from Errorf)
-	Annotations map[string]string // Arbitrary key-value annotations (e.g., subaction, resource_id)
-	Stack       []runtime.Frame   // Captured call stack for stack matching
+	Err           error             // The original or wrapped error
+	Message       string            // Optional developer-provided message (from Errorf)
+	Annotations   map[string]string // Arbitrary key-value annotations (e.g., subaction, resource_id)
+	CapturedStack []runtime.Frame   // Captured call stack for stack matching
 }
 
 // Error implements the error interface.
@@ -150,6 +150,11 @@ func (e *Error) Error() string {
 // Unwrap returns the underlying error.
 func (e *Error) Unwrap() error {
 	return e.Err
+}
+
+// Stack returns the captured call stack frames.
+func (e *Error) Stack() []runtime.Frame {
+	return e.CapturedStack
 }
 
 // NewError wraps an existing error with smarterr metadata derived from the call stack.
@@ -169,9 +174,9 @@ func NewError(err error) error {
 	}
 	stack := captureStack(3) // skip 3 to get the caller of NewError
 	return &Error{
-		Err:         err,
-		Annotations: map[string]string{},
-		Stack:       stack,
+		Err:           err,
+		Annotations:   map[string]string{},
+		CapturedStack: stack,
 	}
 }
 
@@ -186,10 +191,10 @@ func Errorf(format string, args ...any) error {
 	msg := fmt.Sprintf(format, args...)
 	stack := captureStack(3) // skip 3 to get the caller of Errorf
 	return &Error{
-		Err:         errors.New(msg),
-		Message:     msg,
-		Annotations: map[string]string{},
-		Stack:       stack,
+		Err:           errors.New(msg),
+		Message:       msg,
+		Annotations:   map[string]string{},
+		CapturedStack: stack,
 	}
 }
 

--- a/smarterr.go
+++ b/smarterr.go
@@ -2,8 +2,6 @@ package smarterr
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"runtime"
 
 	"github.com/YakDriver/smarterr/internal"
@@ -24,6 +22,25 @@ func SetFS(fs FileSystem, baseDir string) {
 	Debugf("SetFS called with baseDir=%q", baseDir)
 	wrappedFS = fs
 	wrappedBaseDir = baseDir
+}
+
+// EnrichAppendFW is a helper function that enriches diagnostics with smarterr information.
+// This will not change the severity of either incoming or existing diagnostics, but will change
+// the summary and detail of _incoming_ diagnostics only with smarterr information.
+func EnrichAppendFW(ctx context.Context, existing fwdiag.Diagnostics, incoming fwdiag.Diagnostics, keyvals ...any) {
+	for _, diag := range incoming {
+		if diag == nil {
+			continue
+		}
+
+		// Need care here to deduplicate if either the incoming unenriched diagnostics
+		// or the incoming enriched diagnostics already exist in the existing diagnostics.
+
+		if existing.Contains(diag) {
+			continue
+		}
+		existing = append(existing, diag)
+	}
 }
 
 func AppendFW(ctx context.Context, diags fwdiag.Diagnostics, err error, keyvals ...any) {
@@ -127,84 +144,6 @@ func appendCommon(ctx context.Context, add func(summary, detail string), err err
 	Debugf("renderDiagnostics returned summary=%q detail=%q", summary, detail)
 	add(summary, detail)
 	emitLogTemplates(ctx, cfg, values)
-}
-
-// Error is the enriched smarterr error type.
-// It wraps a base error and includes structured annotations
-// that can be used by AppendSDK/FW to construct clear, user-friendly diagnostics.
-type Error struct {
-	Err           error             // The original or wrapped error
-	Message       string            // Optional developer-provided message (from Errorf)
-	Annotations   map[string]string // Arbitrary key-value annotations (e.g., subaction, resource_id)
-	CapturedStack []runtime.Frame   // Captured call stack for stack matching
-}
-
-// Error implements the error interface.
-func (e *Error) Error() string {
-	if e.Message != "" {
-		return e.Message
-	}
-	return e.Err.Error()
-}
-
-// Unwrap returns the underlying error.
-func (e *Error) Unwrap() error {
-	return e.Err
-}
-
-// Stack returns the captured call stack frames.
-func (e *Error) Stack() []runtime.Frame {
-	return e.CapturedStack
-}
-
-// NewError wraps an existing error with smarterr metadata derived from the call stack.
-// It automatically annotates the error with context-aware information (e.g., sub-action)
-// without requiring developer input, reducing fragility and promoting consistent error enrichment.
-//
-// Use NewError at the site where an error is first returned or recognized.
-// The resulting error can be passed directly to smarterr.AppendSDK or smarterr.AppendFW
-// without needing manual WithField-style annotation.
-//
-// Example:
-//
-//	return nil, smarterr.NewError(err)
-func NewError(err error) error {
-	if err == nil {
-		return nil
-	}
-	stack := captureStack(3) // skip 3 to get the caller of NewError
-	return &Error{
-		Err:           err,
-		Annotations:   map[string]string{},
-		CapturedStack: stack,
-	}
-}
-
-// Errorf formats according to a format specifier and returns a smarterr-enriched error.
-// It behaves like fmt.Errorf, but also captures contextual metadata based on the call site.
-// This ensures consistent DX and structured diagnostics with minimal developer effort.
-//
-// Example:
-//
-//	return smarterr.Errorf("unexpected result for alarm %q", name)
-func Errorf(format string, args ...any) error {
-	msg := fmt.Sprintf(format, args...)
-	stack := captureStack(3) // skip 3 to get the caller of Errorf
-	return &Error{
-		Err:           errors.New(msg),
-		Message:       msg,
-		Annotations:   map[string]string{},
-		CapturedStack: stack,
-	}
-}
-
-// Assert wraps a call returning (T, error) with smarterr.NewError on failure.
-// Go doesn't yet support generics-based tuple unpacking, so this form works well for now.
-func Assert[T any](val T, err error) (T, error) {
-	if err != nil {
-		return val, NewError(err)
-	}
-	return val, nil
 }
 
 // captureStack returns a slice of runtime.Frames for the current call stack, skipping 'skip' frames.

--- a/smarterr.go
+++ b/smarterr.go
@@ -2,6 +2,8 @@ package smarterr
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"runtime"
 
 	"github.com/YakDriver/smarterr/internal"
@@ -125,6 +127,95 @@ func appendCommon(ctx context.Context, add func(summary, detail string), err err
 	Debugf("renderDiagnostics returned summary=%q detail=%q", summary, detail)
 	add(summary, detail)
 	emitLogTemplates(ctx, cfg, values)
+}
+
+// Error is the enriched smarterr error type.
+// It wraps a base error and includes structured annotations
+// that can be used by AppendSDK/FW to construct clear, user-friendly diagnostics.
+type Error struct {
+	Err         error             // The original or wrapped error
+	Message     string            // Optional developer-provided message (from Errorf)
+	Annotations map[string]string // Arbitrary key-value annotations (e.g., subaction, resource_id)
+	Stack       []runtime.Frame   // Captured call stack for stack matching
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return e.Err.Error()
+}
+
+// Unwrap returns the underlying error.
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
+// NewError wraps an existing error with smarterr metadata derived from the call stack.
+// It automatically annotates the error with context-aware information (e.g., sub-action)
+// without requiring developer input, reducing fragility and promoting consistent error enrichment.
+//
+// Use NewError at the site where an error is first returned or recognized.
+// The resulting error can be passed directly to smarterr.AppendSDK or smarterr.AppendFW
+// without needing manual WithField-style annotation.
+//
+// Example:
+//
+//	return nil, smarterr.NewError(err)
+func NewError(err error) error {
+	if err == nil {
+		return nil
+	}
+	stack := captureStack(3) // skip 3 to get the caller of NewError
+	return &Error{
+		Err:         err,
+		Annotations: map[string]string{},
+		Stack:       stack,
+	}
+}
+
+// Errorf formats according to a format specifier and returns a smarterr-enriched error.
+// It behaves like fmt.Errorf, but also captures contextual metadata based on the call site.
+// This ensures consistent DX and structured diagnostics with minimal developer effort.
+//
+// Example:
+//
+//	return smarterr.Errorf("unexpected result for alarm %q", name)
+func Errorf(format string, args ...any) error {
+	msg := fmt.Sprintf(format, args...)
+	stack := captureStack(3) // skip 3 to get the caller of Errorf
+	return &Error{
+		Err:         errors.New(msg),
+		Message:     msg,
+		Annotations: map[string]string{},
+		Stack:       stack,
+	}
+}
+
+// Assert wraps a call returning (T, error) with smarterr.NewError on failure.
+// Go doesn't yet support generics-based tuple unpacking, so this form works well for now.
+func Assert[T any](val T, err error) (T, error) {
+	if err != nil {
+		return val, NewError(err)
+	}
+	return val, nil
+}
+
+// captureStack returns a slice of runtime.Frames for the current call stack, skipping 'skip' frames.
+func captureStack(skip int) []runtime.Frame {
+	pcs := make([]uintptr, 16)
+	n := runtime.Callers(skip, pcs)
+	frames := runtime.CallersFrames(pcs[:n])
+	var stack []runtime.Frame
+	for {
+		frame, more := frames.Next()
+		stack = append(stack, frame)
+		if !more {
+			break
+		}
+	}
+	return stack
 }
 
 // addFallbackInitError handles the fallback for missing FS.


### PR DESCRIPTION
- **Add error_stack token type**
- **Remove called_after functionality**
- **Adjust for use of captured stack vs. live stack**
- **Reorganize errors**
- **Beginning of diagnostic token**
- **Added diagnostic enrichment, untested**
- **Improve diagnostic input support with EnrichAppend**
- **Clarify docs for template type differences**
- **Improve docs**
